### PR TITLE
Closes #4 add ability to ignore forked repositories while generating stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,16 @@ For more information on inaccuracies, see issue
    to the "Secrets" page (bottom left).
 4. Create a new secret with the name `ACCESS_TOKEN` and paste the copied
    personal access token as the value.
-5. If you want to ignore certain repos, add them (separated by commas) to a new
-   secret—created as before—called `EXCLUDED`. If you want to ignore certain 
-   languages, add them (separated by commas) to a new secret called 
-   `EXCLUDED_LANGS`.
+5. It is possible to change the type of statistics reported.
+   - To ignore certain repos, add them (separated by commas) to a new
+     secret—created as before—called `EXCLUDED`.
+   - To ignore certain languages, add them (separated by commas) to a new
+     secret called `EXCLUDED_LANGS`.
+   - To show statistics only for "owned" repositories and not forks with
+     contributions, add an environment variable (under the `env` header in the
+     [main
+     workflow](https://github.com/jstrieb/github-stats/blob/master/.github/workflows/main.yml)
+     called `EXCLUDE_FORKED_REPOS` with a value of `true`.
 6. Go to the [Actions
    Page](../../actions?query=workflow%3A"Generate+Stats+Images") and press "Run
    Workflow" on the right side of the screen to generate images for the first

--- a/generate_images.py
+++ b/generate_images.py
@@ -105,11 +105,13 @@ async def main() -> None:
     exclude_langs = os.getenv("EXCLUDED_LANGS")
     exclude_langs = ({x.strip() for x in exclude_langs.split(",")}
                      if exclude_langs else None)
+    # Convert a truthy value to a Boolean
+    ignore_forked_repos = not not os.getenv("EXCLUDE_FORKED_REPOS")
     async with aiohttp.ClientSession() as session:
         s = Stats(user, access_token, session, exclude_repos=exclude_repos,
-                  exclude_langs=exclude_langs)
+                  exclude_langs=exclude_langs,
+                  ignore_forked_repos=ignore_forked_repos)
         await asyncio.gather(generate_languages(s), generate_overview(s))
-
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/github_stats.py
+++ b/github_stats.py
@@ -232,8 +232,10 @@ class Stats(object):
     def __init__(self, username: str, access_token: str,
                  session: aiohttp.ClientSession,
                  exclude_repos: Optional[Set] = None,
-                 exclude_langs: Optional[Set] = None):
+                 exclude_langs: Optional[Set] = None,
+                 ignore_forked_repos: bool = False):
         self.username = username
+        self._ignore_forked_repos = ignore_forked_repos
         self._exclude_repos = set() if exclude_repos is None else exclude_repos
         self._exclude_langs = set() if exclude_langs is None else exclude_langs
         self.queries = Queries(username, access_token, session)
@@ -246,10 +248,6 @@ class Stats(object):
         self._repos = None
         self._lines_changed = None
         self._views = None
-        
-        self._ignore_forked_repositories = False
-        if len(os.getenv("IGNORE_FORKED_REPOSITORIES")) != 0:
-            self._ignore_forked_repositories = True
 
     async def to_str(self) -> str:
         """
@@ -308,10 +306,9 @@ Languages:
                            .get("data", {})
                            .get("viewer", {})
                            .get("repositories", {}))
-            
+
             repos = owned_repos.get("nodes", [])
-            if not self._ignore_forked_repositories:
-                # count contributed repos only if flag is not set
+            if not self._ignore_forked_repos:
                 repos += contrib_repos.get("nodes", [])
 
             for repo in repos:

--- a/github_stats.py
+++ b/github_stats.py
@@ -246,6 +246,10 @@ class Stats(object):
         self._repos = None
         self._lines_changed = None
         self._views = None
+        
+        self._ignore_forked_repositories = False
+        if len(os.getenv("IGNORE_FORKED_REPOSITORIES")) != 0:
+            self._ignore_forked_repositories = True
 
     async def to_str(self) -> str:
         """
@@ -304,8 +308,11 @@ Languages:
                            .get("data", {})
                            .get("viewer", {})
                            .get("repositories", {}))
-            repos = (contrib_repos.get("nodes", [])
-                     + owned_repos.get("nodes", []))
+            
+            repos = owned_repos.get("nodes", [])
+            if not self._ignore_forked_repositories:
+                # count contributed repos only if flag is not set
+                repos += contrib_repos.get("nodes", [])
 
             for repo in repos:
                 name = repo.get("nameWithOwner")


### PR DESCRIPTION
I have implemented the code such that if we create a secret named IGNORE_FORKED_REPOSITORIES with any value it will ignore the contrib_repos for all the stats. This in my opinion closes #4