### PR TITLE
Feat: use grid layout for language card

### DIFF
--- a/generate_images.py
+++ b/generate_images.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import re
+from functools import reduce
 
 import aiohttp
 
@@ -62,13 +63,17 @@ async def generate_languages(s: Stats) -> None:
     sorted_languages = sorted(
         (await s.languages).items(), reverse=True, key=lambda t: t[1].get("size")
     )
+    # only show the top 10 languages
+    top10_languages = sorted_languages[:10]
+    percent_scale = 100 / reduce(lambda acc,cur: acc + cur[1].get("prop"), top10_languages, 0)
     delay_between = 150
-    for i, (lang, data) in enumerate(sorted_languages):
+    for i, (lang, data) in enumerate(top10_languages):
         color = data.get("color")
         color = color if color is not None else "#000000"
+        percentage = data.get("prop", 0) * percent_scale
         progress += (
             f'<span style="background-color: {color};'
-            f'width: {data.get("prop", 0):0.3f}%;" '
+            f'width: {percentage:0.3f}%;" '
             f'class="progress-item"></span>'
         )
         lang_list += f"""
@@ -77,9 +82,8 @@ async def generate_languages(s: Stats) -> None:
 viewBox="0 0 16 16" version="1.1" width="16" height="16"><path
 fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8z"></path></svg>
 <span class="lang">{lang}</span>
-<span class="percent">{data.get("prop", 0):0.2f}%</span>
+<span class="percent">{percentage:0.2f}%</span>
 </li>
-
 """
 
     output = re.sub(r"{{ progress }}", progress, output)

--- a/templates/languages.svg
+++ b/templates/languages.svg
@@ -41,6 +41,9 @@ h2 {
 }
 
 ul {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  flex: 1;
   list-style: none;
   padding-left: 0;
   margin-top: 0;
@@ -67,6 +70,8 @@ li {
 }
 
 div.ellipsis {
+  display: flex;
+  flex-flow: column;
   height: var(--foreign-object-height);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/templates/languages.svg
+++ b/templates/languages.svg
@@ -1,5 +1,14 @@
-<svg width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<svg id="card-top-langs" width="360" height="210" xmlns="http://www.w3.org/2000/svg">
 <style>
+#card-top-langs {
+  --card-width: 360px;
+  --card-height: 210px;
+  --background-width: calc(var(--card-width) - 10px);
+  --background-height: calc(var(--card-height) - 10px);
+  --foreign-object-width: calc(var(--card-width) - 42px);
+  --foreign-object-height: calc(var(--card-height) - 34px);
+}
+
 svg {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 14px;
@@ -7,8 +16,8 @@ svg {
 }
 
 #background {
-  width: calc(100% - 10px);
-  height: calc(100% - 10px);
+  width: var(--background-width);
+  height: var(--background-height);
   fill: white;
   stroke: rgb(225, 228, 232);
   stroke-width: 1px;
@@ -17,8 +26,8 @@ svg {
 }
 
 foreignObject {
-  width: calc(100% - 10px - 32px);
-  height: calc(100% - 10px - 24px);
+  width: var(--foreign-object-width);
+  height: var(--foreign-object-height);
 }
 
 h2 {
@@ -58,7 +67,7 @@ li {
 }
 
 div.ellipsis {
-  height: 100%;
+  height: var(--foreign-object-height);
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/templates/overview.svg
+++ b/templates/overview.svg
@@ -1,5 +1,14 @@
-<svg width="360" height="210" xmlns="http://www.w3.org/2000/svg">
+<svg id="card-overview" width="360" height="210" xmlns="http://www.w3.org/2000/svg">
 <style>
+#card-overview {
+  --card-width: 360px;
+  --card-height: 210px;
+  --background-width: calc(var(--card-width) - 10px);
+  --background-height: calc(var(--card-height) - 10px);
+    --foreign-object-width: calc(var(--card-width) - 42px);
+  --foreign-object-height: calc(var(--card-height) - 42px);
+}
+
 svg {
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 14px;
@@ -7,8 +16,8 @@ svg {
 }
 
 #background {
-  width: calc(100% - 10px);
-  height: calc(100% - 10px);
+  width: var(--background-width);
+  height: var(--background-height);
   fill: white;
   stroke: rgb(225, 228, 232);
   stroke-width: 1px;
@@ -17,12 +26,12 @@ svg {
 }
 
 foreignObject {
-  width: calc(100% - 10px - 32px);
-  height: calc(100% - 10px - 32px);
+  width: var(--foreign-object-width);
+  height: var(--foreign-object-height);
 }
 
 table {
-  width: 100%;
+  width: var(--width);
   border-collapse: collapse;
   table-layout: auto;
 }


### PR DESCRIPTION
### Summary

This PR

1. manages elements' size with CSS variables,
2. uses grid layout in the language card for a better display,
3. limits the number of languages to `10`, which is the max capacity of the current design

### Results

| Before | After |
|:-----:|:-----:|
| ![before](https://raw.githubusercontent.com/idiotWu/github-stats/57afe8b1bb23561118ee9f6949432bfadace0266/generated/languages.svg) | ![after](https://raw.githubusercontent.com/idiotWu/github-stats/master/generated/languages.svg) |
