### PR TITLE
Normalize excluded languages comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ For more information on inaccuracies, see issue
      `jstrieb/github-stats`) separated by commas to a new secret—created as
      before—called `EXCLUDED`.
    - To ignore certain languages, add them (separated by commas) to a new
-     secret called `EXCLUDED_LANGS`. E.g. to exclude HTML and TeX you could set
-     the value to `html,tex`.
+     secret called `EXCLUDED_LANGS`. For example, to exclude HTML and TeX you
+     could set the value to `html,tex`.
    - To show statistics only for "owned" repositories and not forks with
      contributions, add an environment variable (under the `env` header in the
      [main

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ For more information on inaccuracies, see issue
      `jstrieb/github-stats`) separated by commas to a new secret—created as
      before—called `EXCLUDED`.
    - To ignore certain languages, add them (separated by commas) to a new
-     secret called `EXCLUDED_LANGS`.
+     secret called `EXCLUDED_LANGS`. E.g. to exclude HTML and TeX you could set
+     the value to `html,tex`.
    - To show statistics only for "owned" repositories and not forks with
      contributions, add an environment variable (under the `env` header in the
      [main

--- a/github_stats.py
+++ b/github_stats.py
@@ -262,7 +262,9 @@ class Stats(object):
         self.username = username
         self._ignore_forked_repos = ignore_forked_repos
         self._exclude_repos = set() if exclude_repos is None else exclude_repos
-        self._exclude_langs = set() if exclude_langs is None else exclude_langs
+        self._exclude_langs = (
+            set() if exclude_langs is None else {x.lower() for x in exclude_langs}
+        )
         self.queries = Queries(username, access_token, session)
 
         self._name: Optional[str] = None
@@ -348,7 +350,7 @@ Languages:
                 for lang in repo.get("languages", {}).get("edges", []):
                     name = lang.get("node", {}).get("name", "Other")
                     languages = await self.languages
-                    if name in self._exclude_langs:
+                    if name.lower() in self._exclude_langs:
                         continue
                     if name in languages:
                         languages[name]["size"] += lang.get("size", 0)

--- a/github_stats.py
+++ b/github_stats.py
@@ -262,9 +262,7 @@ class Stats(object):
         self.username = username
         self._ignore_forked_repos = ignore_forked_repos
         self._exclude_repos = set() if exclude_repos is None else exclude_repos
-        self._exclude_langs = (
-            set() if exclude_langs is None else {x.lower() for x in exclude_langs}
-        )
+        self._exclude_langs = set() if exclude_langs is None else exclude_langs
         self.queries = Queries(username, access_token, session)
 
         self._name: Optional[str] = None
@@ -305,6 +303,8 @@ Languages:
         self._forks = 0
         self._languages = dict()
         self._repos = set()
+
+        exclude_langs_lower = {x.lower() for x in self._exclude_langs}
 
         next_owned = None
         next_contrib = None
@@ -350,7 +350,7 @@ Languages:
                 for lang in repo.get("languages", {}).get("edges", []):
                     name = lang.get("node", {}).get("name", "Other")
                     languages = await self.languages
-                    if name.lower() in self._exclude_langs:
+                    if name.lower() in exclude_langs_lower:
                         continue
                     if name in languages:
                         languages[name]["size"] += lang.get("size", 0)


### PR DESCRIPTION
It's not clear for users how the `EXCLUDED_LANGS` secret should be populated:
* html,tex
* HTML,TeX
?

Avoid all question marks by normalizing both strings to
lower case before they are compared.

I tried this and it worked for me!

Fixes #64