### PR TITLE
Remove unneeded booleanization from `ignore_forked_repos` init

### DIFF
--- a/generate_images.py
+++ b/generate_images.py
@@ -35,14 +35,14 @@ async def generate_overview(s: Stats) -> None:
     with open("templates/overview.svg", "r") as f:
         output = f.read()
 
-    output = re.sub("{{ name }}", await s.name, output)
-    output = re.sub("{{ stars }}", f"{await s.stargazers:,}", output)
-    output = re.sub("{{ forks }}", f"{await s.forks:,}", output)
-    output = re.sub("{{ contributions }}", f"{await s.total_contributions:,}", output)
+    output = output.replace("{{ name }}", await s.name)
+    output = output.replace("{{ stars }}", f"{await s.stargazers:,}")
+    output = output.replace("{{ forks }}", f"{await s.forks:,}")
+    output = output.replace("{{ contributions }}", f"{await s.total_contributions:,}")
     changed = (await s.lines_changed)[0] + (await s.lines_changed)[1]
-    output = re.sub("{{ lines_changed }}", f"{changed:,}", output)
-    output = re.sub("{{ views }}", f"{await s.views:,}", output)
-    output = re.sub("{{ repos }}", f"{len(await s.repos):,}", output)
+    output = output.replace("{{ lines_changed }}", f"{changed:,}")
+    output = output.replace("{{ views }}", f"{await s.views:,}")
+    output = output.replace("{{ repos }}", f"{len(await s.repos):,}")
 
     generate_output_folder()
     with open("generated/overview.svg", "w") as f:
@@ -82,8 +82,8 @@ fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8z"></path></svg>
 
 """
 
-    output = re.sub(r"{{ progress }}", progress, output)
-    output = re.sub(r"{{ lang_list }}", lang_list, output)
+    output = output.replace(r"{{ progress }}", progress)
+    output = output.replace(r"{{ lang_list }}", lang_list)
 
     generate_output_folder()
     with open("generated/languages.svg", "w") as f:

--- a/generate_images.py
+++ b/generate_images.py
@@ -117,7 +117,7 @@ async def main() -> None:
     # Convert a truthy value to a Boolean
     raw_ignore_forked_repos = os.getenv("EXCLUDE_FORKED_REPOS")
     ignore_forked_repos = (
-        not not raw_ignore_forked_repos
+        raw_ignore_forked_repos
         and raw_ignore_forked_repos.strip().lower() != "false"
     )
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
The `and` makes expression return truthy/falsy already