### PR TITLE
Filter inherited stats by ownership

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         EXCLUDE_REPOS: ${{ secrets.EXCLUDE_REPOS }}
         EXCLUDE_LANGS: ${{ secrets.EXCLUDE_LANGS }}
         EXCLUDE_PRIVATE: "false"
-        EXCLUDE_INHERITED: "true"
+        EXCLUDE_INHERITED: "false"
         SILENT: "true"
         # TODO: Remove this when they get their API working again
         # https://github.com/orgs/community/discussions/192970

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         EXCLUDE_REPOS: ${{ secrets.EXCLUDE_REPOS }}
         EXCLUDE_LANGS: ${{ secrets.EXCLUDE_LANGS }}
         EXCLUDE_PRIVATE: "false"
+        EXCLUDE_INHERITED: "true"
         SILENT: "true"
         # TODO: Remove this when they get their API working again
         # https://github.com/orgs/community/discussions/192970

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,6 +45,7 @@ const Args = struct {
     exclude_repos: ?[]const u8 = null,
     exclude_langs: ?[]const u8 = null,
     exclude_private: bool = false,
+    exclude_inherited: bool = false,
     overview_output_file: ?[]const u8 = null,
     languages_output_file: ?[]const u8 = null,
     overview_template: ?[]const u8 = null,
@@ -274,6 +275,9 @@ pub fn main(init: std.process.Init) !void {
         {
             continue;
         }
+        const is_owned = !repository.fork and
+            std.mem.eql(u8, repository.owner_login, stats.user);
+        if (args.exclude_inherited and !is_owned) continue;
         aggregate_stats.stars += repository.stars;
         aggregate_stats.forks += repository.forks;
         aggregate_stats.lines_changed += repository.lines_changed;

--- a/src/statistics.zig
+++ b/src/statistics.zig
@@ -22,9 +22,12 @@ const Repository = struct {
     lines_changed: u32,
     views: u32,
     private: bool,
+    fork: bool,
+    owner_login: []const u8,
 
     pub fn deinit(self: @This(), allocator: std.mem.Allocator) void {
         allocator.free(self.name);
+        allocator.free(self.owner_login);
         if (self.languages) |languages| {
             for (languages) |language| {
                 language.deinit(allocator);
@@ -264,6 +267,8 @@ fn getReposByYear(
         \\          stargazerCount
         \\          forkCount
         \\          isPrivate
+        \\          isFork
+        \\          owner { login }
         \\          languages(
         \\              first: 100,
         \\              orderBy: { direction: DESC, field: SIZE }
@@ -320,6 +325,8 @@ fn getReposByYear(
                         stargazerCount: u32,
                         forkCount: u32,
                         isPrivate: bool,
+                        isFork: bool,
+                        owner: struct { login: []const u8 },
                         languages: ?struct {
                             edges: ?[]struct {
                                 size: u32,
@@ -388,9 +395,11 @@ fn getReposByYear(
         }
         var repository = Repository{
             .name = try context.allocator.dupe(u8, raw_repo.nameWithOwner),
+            .owner_login = try context.allocator.dupe(u8, raw_repo.owner.login),
             .stars = raw_repo.stargazerCount,
             .forks = raw_repo.forkCount,
             .private = raw_repo.isPrivate,
+            .fork = raw_repo.isFork,
             .languages = null,
             .views = 0,
             .lines_changed = 0,


### PR DESCRIPTION
Adds an EXCLUDE_INHERITED flag that, when enabled, restricts aggregated stats (stars, forks, lines changed, views, repos) to repositories the authenticated user actually owns — i.e. not forks, and where the owner login matches the user.

Why: Contributed-to repositories and forks can inflate star/fork counts and language breakdowns, making the stats card misleading as a measure of a user's own output. This flag lets users opt into a stricter, ownership-based view.

Fixes #152 